### PR TITLE
Added GetSystemTimes. New win32-def required.

### DIFF
--- a/src/lib/kernel32/api.ts
+++ b/src/lib/kernel32/api.ts
@@ -57,6 +57,8 @@ export interface Win32Fns extends FM.DllFuncsModel {
    * Note: The return value NULL would be converted to zero by node-ffi
    */
   SetThreadExecutionState(esFlags: M.UINT): M.UINT
+
+  GetSystemTimes(lpIdleTime: M.PFILETIME, lpKernelTime: M.PFILETIME, lpUserTime: M.PFILETIME): M.BOOL
 }
 
 export const apiDef: FM.DllFuncs = {
@@ -87,4 +89,6 @@ export const apiDef: FM.DllFuncs = {
   SetLastError: [W.VOID, [W.DWORD] ],
 
   SetThreadExecutionState: [W.INT, [W.INT] ],
+
+  GetSystemTimes: [W.BOOL, [W.PFILETIME, W.PFILETIME, W.PFILETIME] ],
 }

--- a/test/30_kernel32.test.ts
+++ b/test/30_kernel32.test.ts
@@ -1,0 +1,32 @@
+/// <reference types="node" />
+/// <reference types="mocha" />
+
+import { basename } from 'path'
+import * as assert from 'power-assert'
+import {
+    DModel as M,
+    DStruct as DS,
+} from 'win32-def'
+
+import {
+    knl32,
+    Struct,
+} from './helper'
+
+const filename = basename(__filename)
+
+describe(filename, () => {
+  it('invoke GetSystemTime', () => {
+    const idleTime: M.FILETIME_Struct = new Struct(DS.FILETIME)()
+    const kernelTime: M.FILETIME_Struct = new Struct(DS.FILETIME)()
+    const userTime: M.FILETIME_Struct = new Struct(DS.FILETIME)()
+    knl32.GetSystemTimes(idleTime.ref(), kernelTime.ref(), userTime.ref())
+    assert(fileTimeToNumber(idleTime) > 0)
+    assert(fileTimeToNumber(kernelTime) > 0)
+    assert(fileTimeToNumber(userTime) > 0)
+  })
+})
+
+function fileTimeToNumber(fileTime: M.FILETIME_Struct): number {
+  return fileTime.dwLowDateTime + fileTime.dwHighDateTime * Math.pow(2, 32)
+}


### PR DESCRIPTION
The win32-def that is required (and you would need to bump the package.json on) is in this pull request: https://github.com/waitingsong/node-win32-def/pull/2


My reasoning for this addition is that I want to use this module in system-information such that they don't query WMIC for everything, which seems like a lot less efficient (opening a console. running a cmd. parsing the results. etc etc.) than just calling straight into the DLL with ffi.