### PR TITLE
Add GenerateConsoleCtrlEvent()

### DIFF
--- a/packages/win32-api/src/lib/kernel32/api.ts
+++ b/packages/win32-api/src/lib/kernel32/api.ts
@@ -18,6 +18,8 @@ export interface Win32Fns extends FM.DllFuncsModel {
 
   FreeConsole: () => M.BOOL
 
+  GenerateConsoleCtrlEvent: (dwCtrlEvent: M.DWORD, dwProcessGroupId: M.DWORD) => M.BOOL
+
   /**
    * Not works correctly
    * @see https://github.com/node-ffi/node-ffi/issues/261
@@ -73,6 +75,8 @@ export const apiDef: FM.DllFuncs = {
   ],
 
   FreeConsole: [W.BOOL, [] ],
+  
+  GenerateConsoleCtrlEvent: [W.BOOL, [W.DWORD, W.DWORD] ],
 
   /** err code: https://msdn.microsoft.com/zh-cn/library/windows/desktop/ms681381(v=vs.85).aspx */
   GetLastError: [W.DWORD, [] ],


### PR DESCRIPTION
Adds [GenerateConsoleCtrlEvent](https://docs.microsoft.com/en-us/windows/console/generateconsolectrlevent#remarks) to the Kernel32 library. This is useful for sending ctrl+c signal to all processes attached to the current console, causing their `SIGINT` event handlers to fire, causing them to exit gracefully (i.e. after cleaning up if necessary). Some related discussion: https://github.com/nodejs/node/issues/35172#issuecomment-691624790

In the linked documentation (under ["Parameters"](https://docs.microsoft.com/en-us/windows/console/generateconsolectrlevent#parameters)) we see that the `dwCtrlEvent` parameter uses an enumeration:
- `CTRL_C_EVENT` is `0`
- `CTRL_BREAK_EVENT` is `1` 

Is there some way we should include this enumeration in this library?

For now it is possible to just use the number value.

/cc @waitingsong and thanks for the awesome library ❤️ 