### PR TITLE
Add support for IsIconic and SetWindowPos

### DIFF
--- a/packages/win32-api/src/lib/user32/api.ts
+++ b/packages/win32-api/src/lib/user32/api.ts
@@ -127,6 +127,8 @@ export interface Win32Fns {
 
   GetWindowThreadProcessId: (hWnd: M.HWND, lpdwProcessId: M.LPDWORD | null) => M.DWORD
 
+  IsIconic: (hWnd: M.HWND) => M.BOOL
+
   IsWindowVisible: (hWnd: M.HWND) => M.BOOL
 
   PeekMessageW: (
@@ -158,6 +160,8 @@ export interface Win32Fns {
 
   /** https://docs.microsoft.com/zh-cn/windows/win32/api/winuser/nf-winuser-setforegroundwindow */
   SetForegroundWindow: (hWnd: M.HWND) => M.BOOL
+
+  SetWindowPos: (hWnd: M.HWND, hWndInsertAfter: M.HWND | null, X: M.INT, Y: M.INT, cx: M.INT, cy: M.INT, uFlags: M.UINT) => M.BOOL
 
   SetWindowTextW: (hWnd: M.HWND, lpString: M.LPCTSTR | null) => M.BOOL
 
@@ -257,6 +261,8 @@ export const apiDef: M.DllFuncs<Win32Fns> = {
 
   GetWindowThreadProcessId: [W.DWORD, [W.HWND, W.LPDWORD] ],
 
+  IsIconic: [W.BOOL, [W.HWND] ],
+
   IsWindowVisible: [W.BOOL, [W.HWND] ],
 
   PeekMessageW: [W.BOOL, [W.LPMSG, W.HWND, W.UINT, W.UINT, W.UINT] ],
@@ -270,6 +276,8 @@ export const apiDef: M.DllFuncs<Win32Fns> = {
   SendMessageW: [W.LRESULT, [W.HWND, W.UINT, W.WPARAM, W.LPARAM] ],
 
   SetForegroundWindow: [W.BOOL, [W.HWND] ],
+
+  SetWindowPos: [W.BOOL, [W.HWND, W.HWND, W.INT, W.INT, W.INT, W.INT, W.UINT] ],
 
   SetWindowTextW: [W.BOOL, [W.HWND, W.LPCTSTR] ],
 

--- a/packages/win32-api/src/lib/user32/api.ts
+++ b/packages/win32-api/src/lib/user32/api.ts
@@ -161,7 +161,14 @@ export interface Win32Fns {
   /** https://docs.microsoft.com/zh-cn/windows/win32/api/winuser/nf-winuser-setforegroundwindow */
   SetForegroundWindow: (hWnd: M.HWND) => M.BOOL
 
-  SetWindowPos: (hWnd: M.HWND, hWndInsertAfter: M.HWND | null, X: M.INT, Y: M.INT, cx: M.INT, cy: M.INT, uFlags: M.UINT) => M.BOOL
+  SetWindowPos: (
+    hWnd: M.HWND,
+    hWndInsertAfter: M.HWND | null,
+    X: M.INT,
+    Y: M.INT,
+    cx: M.INT,
+    cy: M.INT,
+    uFlags: M.UINT) => M.BOOL
 
   SetWindowTextW: (hWnd: M.HWND, lpString: M.LPCTSTR | null) => M.BOOL
 

--- a/packages/win32-api/src/lib/user32/constants.ts
+++ b/packages/win32-api/src/lib/user32/constants.ts
@@ -51,6 +51,32 @@ export const enum CmdShow {
   SW_FORCEMINIMIZE = 11,
 }
 
+// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowpos
+export const enum CmdSetPos {
+  // values for hWndInsertAfter
+  HWND_BOTTOM = 1,
+  HWND_NOTOPMOST = -2,
+  HWND_TOP = 0,
+  HWND_TOPMOST = -1,
+
+  // values for uFlags
+  SWP_ASYNCWINDOWPOS = 0x4000,
+  SWP_DEFERERASE = 0x2000,
+  SWP_DRAWFRAME = 0x0020,
+  SWP_FRAMECHANGED = 0x0020,
+  SWP_HIDEWINDOW = 0x0080,
+  SWP_NOACTIVATE = 0x0010,
+  SWP_NOCOPYBITS = 0x0100,
+  SWP_NOMOVE = 0x0002,
+  SWP_NOOWNERZORDER = 0x0200,
+  SWP_NOREDRAW = 0x0008,
+  SWP_NOREPOSITION = 0x0200,
+  SWP_NOSENDCHANGING = 0x0400,
+  SWP_NOSIZE = 0x0001,
+  SWP_NOZORDER = 0x0004,
+  SWP_SHOWWINDOW = 0x0040,
+}
+
 /* --------- Window Styles ---------------- */
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms632600(v=vs.85).aspx
 export const WS_BORDER = 0x00800000

--- a/packages/win32-api/test/user32/63.IsIconic.test.ts
+++ b/packages/win32-api/test/user32/63.IsIconic.test.ts
@@ -1,15 +1,17 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { fileShortPath} from '@waiting/shared-core';
+
+import { fileShortPath } from '@waiting/shared-core'
 import { sleep } from 'zx'
+
 import { user32FindWindowEx } from '../../src/index.fun.js'
 import { calcLpszWindow } from '../config.unittest.js'
-
 import { user32, destroyWin } from '../helper.js'
 
+
 describe(fileShortPath(import.meta.url), () => {
-  it("IsIconic()", async () => {
-    const child = spawn("calc.exe")
+  it('IsIconic()', async () => {
+    const child = spawn('calc.exe')
     await sleep(1500)
 
     const hWnd = await user32FindWindowEx(0, 0, null, calcLpszWindow)

--- a/packages/win32-api/test/user32/63.IsIconic.test.ts
+++ b/packages/win32-api/test/user32/63.IsIconic.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { fileShortPath} from '@waiting/shared-core';
+import { sleep } from 'zx'
+import { user32FindWindowEx } from '../../src/index.fun.js'
+import { calcLpszWindow } from '../config.unittest.js'
+
+import { user32, destroyWin } from '../helper.js'
+
+describe(fileShortPath(import.meta.url), () => {
+  it("IsIconic()", async () => {
+    const child = spawn("calc.exe")
+    await sleep(1500)
+
+    const hWnd = await user32FindWindowEx(0, 0, null, calcLpszWindow)
+    assert((typeof hWnd === 'string' && hWnd.length > 0) || hWnd > 0, 'invalid hWnd')
+
+    assert(! await user32.IsIconic(hWnd))
+    await user32.ShowWindow(hWnd, 2) // minimize
+    assert(await user32.IsIconic(hWnd))
+
+    await destroyWin(hWnd)
+    child.kill()
+  })
+})


### PR DESCRIPTION
This is an initial attempt to support [`IsIconic`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-isiconic) and [`SetWindowPos`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowpos).

I did it blindly since I wasn't able to get the unit tests to run properly (even before my changes). 

I also added constants similar to `CmdShow` is this the intended way? I don't see it used in any of the demos.