### PR TITLE
Add recursive Struct support

### DIFF
--- a/packages/win32-def/src/lib/struct/struct.types.ts
+++ b/packages/win32-def/src/lib/struct/struct.types.ts
@@ -215,8 +215,8 @@ export type LPRECT = _POINTER
 
 export interface WINDOWINFO extends StructInstanceBase {
   cbSize: DWORD
-  rcWindow: VOID
-  rcClient: VOID
+  rcWindow: RECT
+  rcClient: RECT
   dwStyle: DWORD
   dwExStyle: DWORD
   dwWindowStatus: DWORD


### PR DESCRIPTION
This pull request adds recursive Struct support, which allows `WINDOWINFO.rcWindow` to work correctly.

I ran into some build issues when testing this change, so I had manually injected the change into `node_modules` to test it. But it seemed to work fine when I did that.

Let me know if there is a better way to do this, or if you have any concerns with this change.
Thanks!